### PR TITLE
removing express deprecated warning

### DIFF
--- a/src/api/routes/npmPackage.js
+++ b/src/api/routes/npmPackage.js
@@ -13,7 +13,7 @@ function getPackage(packageName, cb) {
 
 router.get('/', function(req, res) {
 
-  var packageName = req.param('npmPackage')
+  var packageName = req.query['npmPackage'] || ''
   getPackage(packageName, function (error, response, body) {
 
     if (error) {

--- a/src/api/routes/npmPackages.js
+++ b/src/api/routes/npmPackages.js
@@ -8,7 +8,7 @@ function getPackages(keyword, cb) {
   var dlCountUrl    = 'https://api.npmjs.org/downloads/point/last-week';
   var viewsPath     = '-/_view';
   var keywordView   = 'byKeyword';
-  var query         = 'startkey=["' + keyword + '"]' 
+  var query         = 'startkey=["' + keyword + '"]'
       query        += '&endkey=["' + keyword + '",{}]'
       query        += '&group_level=3'
 
@@ -22,7 +22,7 @@ function getPackages(keyword, cb) {
 
 router.get('/', function(req, res) {
 
-  var keyword = req.param('keyword');
+  var keyword = req.query['keyword'] || '';
 
   getPackages(keyword, function (error, response, body) {
 


### PR DESCRIPTION
`req.param('foo')` is deprecated, changing to access the query object.

ps - thanks for this nicely minimal example app!